### PR TITLE
Pass options to swig if we want to set any swig defaults.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swig-email-templates",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "description": "Node.js module for rendering emails with swig templates and email-friendly inline CSS",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Documentation says options will be passed to swig but it was not doing it. This allows you to set swig default options outside of swig-email-templates.
