### PR TITLE
Added ability to specify swig filters

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,11 @@ function init(options, cb) {
   rootFolder = options.root || rootFolder;
 
   swig.setDefaults(options);
+  if (options.filters) {
+    for (var filter in options.filters) {
+      swig.setFilter(filter, options.filters[filter]);
+    }
+  }
   cb(null, render);
     
   function render(templateName, context, urlRewriteFn, cb) {


### PR DESCRIPTION
I added the possibility to specify filters for swig in the init function. This can be very useful if you need more customized output formatting.

I added a filters property in the options parameter for this feature, I think this may be useful for other users too.

Example code for custom (localized) date formatting:

var emailTemplates = require('swig-email-templates');
var moment = require('moment');

var options = {
  root: path.join(__dirname, "templates"),
  filters: {
    momentFormat: function (input, format) {
      return moment(input).format(format);
    }
  }
  // any other swig options allowed here
};

moment.locale('nl');

emailTemplates(options, function (err, render) {
  var context = {
    now: new Date(),
    ...
  };
  render('test.html', context, function (err, html, text) {
    // send the email ...
  }
}

and an example HTML template piece:

<<
This email was sent on {{ now|momentFormat('dddd LL') }} at {{ now|momentFormat('LT') }}
>>