### PR TITLE
Update jsdom dependency, to fix on node version > 0.11.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,6 @@ language: node_js
 node_js:
   - "0.8"
   - "0.10"
+  - "0.12"
+  - "iojs-v1.0.4"
+  - "iojs-v1.6.2"

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ function init(options, cb) {
               tryCleanup();
               cb(err);
             } else {
-              var inner = document.innerHTML;
+              var inner = jsdom.serializeDocument(document);
               tryCleanup();
               generateText(options, context, inner, function(err, text) {
                 if (err) return cb(err);
@@ -87,7 +87,7 @@ function createJsDomInstance(content, cb) {
     }
   };
   try {
-    cb(null, jsdom.html(html, null, options));
+    cb(null, jsdom.jsdom(html, options));
   } catch (err) {
     cb(err);
   }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "swig": "~1.4.1",
     "juice2": "~1.3.0",
-    "jsdom": ">=1.5.0 <=4.0.5",
+    "jsdom": "~3.1.2",
     "optimist": "~0.6.1",
     "html-to-text": "~0.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "swig": "~1.4.1",
     "juice2": "~1.3.0",
-    "jsdom": "~0.11.1",
+    "jsdom": ">=1.5.0 <=4.0.5",
     "optimist": "~0.6.1",
     "html-to-text": "~0.1.0"
   }

--- a/test/templates/comments.out.html
+++ b/test/templates/comments.out.html
@@ -1,4 +1,4 @@
-<html><body>baseOne
+<html><head></head><body>baseOne
 
   ten
   

--- a/test/templates/complex_variable.out.html
+++ b/test/templates/complex_variable.out.html
@@ -1,4 +1,4 @@
-<html><body>scalar
+<html><head></head><body>scalar
 three
 four
 four

--- a/test/templates/for_loop.out.html
+++ b/test/templates/for_loop.out.html
@@ -1,4 +1,4 @@
-<html><body>scalar
+<html><head></head><body>scalar
 
   abcd
   lalala

--- a/test/templates/if_statement.out.html
+++ b/test/templates/if_statement.out.html
@@ -1,4 +1,4 @@
-<html><body>content
+<html><head></head><body>content
 one
 content
 

--- a/test/templates/plays.out.html
+++ b/test/templates/plays.out.html
@@ -3,14 +3,6 @@
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <title>subject</title>
-
-    
-    
-  
-    
-    
-  
-
   </head>
   <body leftmargin="0" marginwidth="0" topmargin="0" marginheight="0" offset="0" style="-webkit-text-size-adjust: none; background-color: #2f2f2f; color: #505050; font-family: 'Lucida Grande', 'Lucida', sans-serif; margin: 0; padding: 0; width: 100%;">
     <center>
@@ -38,12 +30,12 @@
               </tr>
               <tr>
                 <td align="center" valign="top">
-                  
+
 <table border="0" cellpadding="10" cellspacing="0" width="600" id="templateBody">
   <tr>
     <td align="center">
       <table width="560" border="0" style="padding-top: 11px; padding-bottom: 11px;">
-        <tr> 
+        <tr>
           <td width="30%" style="background-color: #e3e3e3;padding-right: 5px;" valign="top" align="left">
             <table style="border: 14px solid #2d2d2d; background-color: #2d2d2d;" cellpadding="0" cellspacing="0" border="0">
               <tr>
@@ -53,13 +45,13 @@
               </tr>
               <tr>
                 <td colspan="2">
-                  <table border="0" cellpadding="0" cellspacing="0" width="100%" height="35" style="padding-top: 10px;">	
+                  <table border="0" cellpadding="0" cellspacing="0" width="100%" height="35" style="padding-top: 10px;">
                     <tr>
                       <td width="33%" align="center" style="background-color: #535250; vertical-align: top;">
                         <table cellpadding="0" cellspacing="0" border="0" style="padding: 4px 0 4px 0;">
                           <tr>
                             <td style="background-color: #535250; vertical-align: middle;" valign="middle" height="18" align="center">
-                              <img src="https://opps-notify.s3.amazonaws.com/play.png" style="border: none; display: block; font-size: 14px; font-weight: bold; height: auto; line-height: 100%; outline: none; padding: 0 2px 0 2px; text-decoration: none; text-transform: capitalize;"> 
+                              <img src="https://opps-notify.s3.amazonaws.com/play.png" style="border: none; display: block; font-size: 14px; font-weight: bold; height: auto; line-height: 100%; outline: none; padding: 0 2px 0 2px; text-decoration: none; text-transform: capitalize;">
                             </td>
                             <td style="background-color: #535250; vertical-align: middle; font-size: 8px; color: #97cc64; padding-right: 2px;" valign="middle">
                               &nbsp;playCount
@@ -78,7 +70,7 @@
                         <table cellpadding="0" cellspacing="0" border="0" style="padding: 4px 0 4px 0;">
                           <tr>
                             <td style="background-color: #535250; vertical-align: middle;" valign="middle" height="18" align="center">
-                              <img src="https://opps-notify.s3.amazonaws.com/dialog_box.png" style="border: none; display: block; font-size: 14px; font-weight: bold; height: auto; line-height: 100%; outline: none; padding: 0 2px 0 2px; text-decoration: none; text-transform: capitalize;"> 
+                              <img src="https://opps-notify.s3.amazonaws.com/dialog_box.png" style="border: none; display: block; font-size: 14px; font-weight: bold; height: auto; line-height: 100%; outline: none; padding: 0 2px 0 2px; text-decoration: none; text-transform: capitalize;">
                             </td>
                             <td style="background-color: #535250; vertical-align: middle; font-size: 8px; color: #97cc64; padding-right: 2px;" valign="middle">
                               &nbsp;commentCount
@@ -97,7 +89,7 @@
                         <table cellpadding="0" cellspacing="0" border="0" style="padding: 4px 0 4px 0;">
                           <tr>
                             <td style="background-color: #535250; vertical-align: middle;" valign="middle" height="18" align="center">
-                              <img src="https://opps-notify.s3.amazonaws.com/check.png" style="border: none; display: block; font-size: 14px; font-weight: bold; height: auto; line-height: 100%; outline: none; padding: 0 2px 0 2px; text-decoration: none; text-transform: capitalize;"> 
+                              <img src="https://opps-notify.s3.amazonaws.com/check.png" style="border: none; display: block; font-size: 14px; font-weight: bold; height: auto; line-height: 100%; outline: none; padding: 0 2px 0 2px; text-decoration: none; text-transform: capitalize;">
                             </td>
                             <td style="background-color: #535250; vertical-align: middle; font-size: 8px; color: #97cc64; padding-right: 2px;" valign="middle">
                               &nbsp;voteCount

--- a/test/templates/simple_vars.out.html
+++ b/test/templates/simple_vars.out.html
@@ -1,2 +1,2 @@
-<html><body>hello
+<html><head></head><body>hello
 </body></html>

--- a/test/templates/two_vars_content.out.html
+++ b/test/templates/two_vars_content.out.html
@@ -1,4 +1,4 @@
-<html><body>headeronemiddle two
+<html><head></head><body>headeronemiddle two
 
 footer
 </body></html>


### PR DESCRIPTION
Fixes #25.

It *might* also help here andrewrk/juice#16, but I didn't touch that since this solves my use case for now.

I fixed 6/7 tests (the new way inserts an empty `<head></head>` element if it's not there), but I couldn't figure out what was wrong here. Any ideas @andrewrk ?

```shell
  6 passing (181ms)
  1 failing

  1) swig-email-templates plays:
     Uncaught Error: callback called twice
      at onCb (/Users/marchi/Project/GitHub/swig-email-templates/node_modules/pend/index.js:32:23)
      at /Users/marchi/Project/GitHub/swig-email-templates/test/test.js:112:11
      at /Users/marchi/Project/GitHub/swig-email-templates/index.js:44:33
      at renderTemplate (/Users/marchi/Project/GitHub/swig-email-templates/index.js:124:5)
      at /Users/marchi/Project/GitHub/swig-email-templates/index.js:104:9
      at compileTemplate (/Users/marchi/Project/GitHub/swig-email-templates/index.js:116:5)
      at /Users/marchi/Project/GitHub/swig-email-templates/index.js:103:7
      at FSReqWrap.cb [as oncomplete] (fs.js:209:19)
```