### PR TITLE
Small tweaks to Example section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,10 +181,10 @@ The options are:
 
 ### Example
 
-The following examples renders two files, `email1.html` and `email2.html`, which are both contained in the cwd. It uses the context stored in `context/main.json` for rendering, and places the results in the folder `output`.
+The following example renders two files, `email1.html` and `email2.html`, which are both contained in the cwd. It uses the context stored in `context/main.json` for rendering, and places the results in the folder `output`.
 
 ```
-swig-email-templates render email1.html email2.html -o output/ -j context/main.json
+swig-email-templates email1.html email2.html -o output/ -j context/main.json
 ```
 
 


### PR DESCRIPTION
Hi there,

I noticed a small discrepancy between the command line tool's API and what's shown in the [Example](https://github.com/andrewrk/swig-email-templates#example-1) section of ```README.md```, namely an extra ```render``` argument which ```swig-email-templates``` believes to be a template file rather than a command.

> swig-email-templates **_render_** email1.html email2.html -o output/ -j context/main.json

This PR simply tweaks ```README.md``` to show (what I believe to be...) the correct usage. Thanks!

##### What's changed: #####
* Remove ```render``` from command line arguments (otherwise
  ```swig-email-templates``` thinks ```render``` is a file like ```email1.html```,
  or ```email2.html``` and throws a node ENOENT exception).

* Replace ```examples``` with ```example``` in description since there's only
  one example provided below it.