### PR TITLE
Replace deprecated dep

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 var path = require('path');
 var fs = require('fs');
-var swig = require('swig');
+var swig = require('swig-templates');
 var juice = require('juice');
 var cheerio = require('cheerio');
 var htmlToText = require('html-to-text');

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "html-to-text": "^2.1.0",
     "juice": "^3.0.0",
     "optimist": "^0.6.1",
-    "swig": "^1.4.2"
+    "swig-templates": "^2.0.2"
   }
 }

--- a/test/output.js
+++ b/test/output.js
@@ -1,5 +1,5 @@
 var EmailTemplates = require('../');
-var swig = require('swig');
+var swig = require('swig-templates');
 var assert = require('assert');
 var path = require('path');
 var Pend = require('pend');


### PR DESCRIPTION
`swig` is not maintained anymore and it has a dependence security issue. 
https://nodesecurity.io/advisories/48

Just replace `swig` for `swig-templates` where this security issue doesn't exist.

This should address #39